### PR TITLE
Fix tfoot in table block

### DIFF
--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -182,13 +182,13 @@ Array [
     <tfoot>
       <tr>
         <th>
-          Name
+          Total
         </th>
         <th>
-          Qtd
+          16 pcs
         </th>
         <th>
-          Price
+          $450
         </th>
       </tr>
     </tfoot>

--- a/src/renderers/table/__snapshots__/index.test.tsx.snap
+++ b/src/renderers/table/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Table /> when receives a simple table renders a <table> tag without <thead>, <tfoot> or <caption> 1`] = `
+<table>
+  <tbody>
+    <tr>
+      <th>
+        Kine
+      </th>
+      <td>
+        1 pcs
+      </td>
+      <td>
+        100$
+      </td>
+    </tr>
+    <tr>
+      <th>
+        Pigs
+      </th>
+      <td>
+        3 pcs
+      </td>
+      <td>
+        200$
+      </td>
+    </tr>
+    <tr>
+      <th>
+        Chickens
+      </th>
+      <td>
+        12 pcs
+      </td>
+      <td>
+        150$
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`<Table /> when receives a table block renders a <table> tag 1`] = `
 <table>
   <caption>
@@ -56,6 +96,27 @@ exports[`<Table /> when receives a table block renders a <table> tag 1`] = `
   <tfoot>
     <tr>
       <th>
+        Total
+      </th>
+      <th>
+        16 pcs
+      </th>
+      <th>
+        $450
+      </th>
+    </tr>
+  </tfoot>
+</table>
+`;
+
+exports[`<Table /> when receives a table block without footer renders a <table> tag without <tfoot> 1`] = `
+<table>
+  <caption>
+    The stock on our store.
+  </caption>
+  <thead>
+    <tr>
+      <th>
         Name
       </th>
       <th>
@@ -65,6 +126,41 @@ exports[`<Table /> when receives a table block renders a <table> tag 1`] = `
         Price
       </th>
     </tr>
-  </tfoot>
+  </thead>
+  <tbody>
+    <tr>
+      <th>
+        Kine
+      </th>
+      <td>
+        1 pcs
+      </td>
+      <td>
+        100$
+      </td>
+    </tr>
+    <tr>
+      <th>
+        Pigs
+      </th>
+      <td>
+        3 pcs
+      </td>
+      <td>
+        200$
+      </td>
+    </tr>
+    <tr>
+      <th>
+        Chickens
+      </th>
+      <td>
+        12 pcs
+      </td>
+      <td>
+        150$
+      </td>
+    </tr>
+  </tbody>
 </table>
 `;

--- a/src/renderers/table/index.test.tsx
+++ b/src/renderers/table/index.test.tsx
@@ -19,4 +19,34 @@ describe('<Table />', () => {
       expect(create(<Table data={data} />).toJSON()).toMatchSnapshot();
     });
   });
+
+  describe('when receives a table block without footer', () => {
+    const data: TableBlockData = {
+      header: ['Name', 'Qtd', 'Price'],
+      content: [
+        ['Kine', '1 pcs', '100$'],
+        ['Pigs', '3 pcs', '200$'],
+        ['Chickens', '12 pcs', '150$'],
+      ],
+      caption: 'The stock on our store.',
+    };
+
+    it('renders a <table> tag without <tfoot>', () => {
+      expect(create(<Table data={data} />).toJSON()).toMatchSnapshot();
+    });
+  });
+
+  describe('when receives a simple table', () => {
+    const data: TableBlockData = {
+      content: [
+        ['Kine', '1 pcs', '100$'],
+        ['Pigs', '3 pcs', '200$'],
+        ['Chickens', '12 pcs', '150$'],
+      ],
+    };
+
+    it('renders a <table> tag without <thead>, <tfoot> or <caption>', () => {
+      expect(create(<Table data={data} />).toJSON()).toMatchSnapshot();
+    });
+  });
 });

--- a/src/renderers/table/index.tsx
+++ b/src/renderers/table/index.tsx
@@ -40,10 +40,10 @@ const Table: RenderFn<TableBlockData> = ({ data, className = '' }) => {
           </tr>
         ))}
       </tbody>
-      {data?.header && (
+      {data?.footer && (
         <tfoot>
           <tr>
-            {data.header.map((cell, i) => (
+            {data?.footer.map((cell, i) => (
               <th key={`${i}`}>{HTMLReactParser(cell)}</th>
             ))}
           </tr>


### PR DESCRIPTION
Previously, footer prop in table was not in use for Table Block.
This PR fixes that.

Closes #15