### PR TITLE
feat: add support for list meta property (start and counterType)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "editorjs-blocks-react-renderer",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "editorjs-blocks-react-renderer",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "html-react-parser": "^1.4.14"

--- a/src/renderers/list/__snapshots__/index.test.tsx.snap
+++ b/src/renderers/list/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<List /> backward compatibility renders ordered list without meta property (default behavior) 1`] = `
+<ol>
+  <li>
+    Item without meta
+  </li>
+  <li>
+    Another item
+  </li>
+</ol>
+`;
+
+exports[`<List /> backward compatibility renders unordered list without meta property 1`] = `
+<ul>
+  <li>
+    Bullet item
+  </li>
+  <li>
+    Another bullet
+  </li>
+</ul>
+`;
+
 exports[`<List /> when receives a list "ordered" block renders a <ol> block 1`] = `
 <ol>
   <li>
@@ -34,6 +56,137 @@ exports[`<List /> when receives a list "unordered" block renders a <ul> block 1`
     Designed to be extendable and pluggable with a simple API
   </li>
 </ul>
+`;
+
+exports[`<List /> when receives a list with meta property with custom start value renders an <ol> block with start attribute 1`] = `
+<ol
+  start={5}
+>
+  <li>
+    First item
+  </li>
+  <li>
+    Second item
+  </li>
+  <li>
+    Third item
+  </li>
+</ol>
+`;
+
+exports[`<List /> when receives a list with meta property with lower-alpha counter type renders an <ol> block with lower-alpha list style 1`] = `
+<ol
+  style={
+    Object {
+      "listStyleType": "lower-alpha",
+    }
+  }
+>
+  <li>
+    First item
+  </li>
+  <li>
+    Second item
+  </li>
+  <li>
+    Third item
+  </li>
+</ol>
+`;
+
+exports[`<List /> when receives a list with meta property with lower-roman counter type renders an <ol> block with lower-roman list style 1`] = `
+<ol
+  style={
+    Object {
+      "listStyleType": "lower-roman",
+    }
+  }
+>
+  <li>
+    First item
+  </li>
+  <li>
+    Second item
+  </li>
+  <li>
+    Third item
+  </li>
+</ol>
+`;
+
+exports[`<List /> when receives a list with meta property with nested lists and meta properties renders nested <ol> blocks with inherited meta properties 1`] = `
+<ol
+  start={3}
+  style={
+    Object {
+      "listStyleType": "upper-roman",
+    }
+  }
+>
+  <li>
+    First level item 1
+  </li>
+  <li>
+    First level item 2
+    <ol
+      start={3}
+      style={
+        Object {
+          "listStyleType": "upper-roman",
+        }
+      }
+    >
+      <li>
+        Nested item 1
+      </li>
+      <li>
+        Nested item 2
+      </li>
+    </ol>
+  </li>
+</ol>
+`;
+
+exports[`<List /> when receives a list with meta property with upper-alpha counter type renders an <ol> block with upper-alpha list style and custom start 1`] = `
+<ol
+  start={2}
+  style={
+    Object {
+      "listStyleType": "upper-alpha",
+    }
+  }
+>
+  <li>
+    First item
+  </li>
+  <li>
+    Second item
+  </li>
+  <li>
+    Third item
+  </li>
+</ol>
+`;
+
+exports[`<List /> when receives a list with meta property with upper-roman counter type renders an <ol> block with upper-roman list style and custom start 1`] = `
+<ol
+  start={3}
+  style={
+    Object {
+      "listStyleType": "upper-roman",
+    }
+  }
+>
+  <li>
+    First item
+  </li>
+  <li>
+    Second item
+  </li>
+  <li>
+    Third item
+  </li>
+</ol>
 `;
 
 exports[`<List /> when receives a nested list "ordered" block and when className is provided renders className to all <ol> blocks 1`] = `

--- a/src/renderers/list/index.test.tsx
+++ b/src/renderers/list/index.test.tsx
@@ -73,4 +73,185 @@ describe('<List />', () => {
       });
     });
   });
+
+  describe('when receives a list with meta property', () => {
+    describe('with custom start value', () => {
+      const data: ListBlockData = {
+        style: 'ordered',
+        items: [
+          'First item',
+          'Second item',
+          'Third item',
+        ],
+        meta: {
+          start: 5,
+          counterType: 'numeric',
+        },
+      };
+
+      it('renders an <ol> block with start attribute', () => {
+        const tree = create(<List data={data} />).toJSON();
+        expect(tree).toMatchSnapshot();
+        // @ts-expect-error - accessing props for testing
+        expect(tree.props.start).toBe(5);
+      });
+    });
+
+    describe('with lower-roman counter type', () => {
+      const data: ListBlockData = {
+        style: 'ordered',
+        items: [
+          'First item',
+          'Second item',
+          'Third item',
+        ],
+        meta: {
+          start: 1,
+          counterType: 'lower-roman',
+        },
+      };
+
+      it('renders an <ol> block with lower-roman list style', () => {
+        const tree = create(<List data={data} />).toJSON();
+        expect(tree).toMatchSnapshot();
+        // @ts-expect-error - accessing props for testing
+        expect(tree.props.style.listStyleType).toBe('lower-roman');
+      });
+    });
+
+    describe('with upper-roman counter type', () => {
+      const data: ListBlockData = {
+        style: 'ordered',
+        items: [
+          'First item',
+          'Second item',
+          'Third item',
+        ],
+        meta: {
+          start: 3,
+          counterType: 'upper-roman',
+        },
+      };
+
+      it('renders an <ol> block with upper-roman list style and custom start', () => {
+        const tree = create(<List data={data} />).toJSON();
+        expect(tree).toMatchSnapshot();
+        // @ts-expect-error - accessing props for testing
+        expect(tree.props.start).toBe(3);
+        // @ts-expect-error - accessing props for testing
+        expect(tree.props.style.listStyleType).toBe('upper-roman');
+      });
+    });
+
+    describe('with lower-alpha counter type', () => {
+      const data: ListBlockData = {
+        style: 'ordered',
+        items: [
+          'First item',
+          'Second item',
+          'Third item',
+        ],
+        meta: {
+          start: 1,
+          counterType: 'lower-alpha',
+        },
+      };
+
+      it('renders an <ol> block with lower-alpha list style', () => {
+        const tree = create(<List data={data} />).toJSON();
+        expect(tree).toMatchSnapshot();
+        // @ts-expect-error - accessing props for testing
+        expect(tree.props.style.listStyleType).toBe('lower-alpha');
+      });
+    });
+
+    describe('with upper-alpha counter type', () => {
+      const data: ListBlockData = {
+        style: 'ordered',
+        items: [
+          'First item',
+          'Second item',
+          'Third item',
+        ],
+        meta: {
+          start: 2,
+          counterType: 'upper-alpha',
+        },
+      };
+
+      it('renders an <ol> block with upper-alpha list style and custom start', () => {
+        const tree = create(<List data={data} />).toJSON();
+        expect(tree).toMatchSnapshot();
+        // @ts-expect-error - accessing props for testing
+        expect(tree.props.start).toBe(2);
+        // @ts-expect-error - accessing props for testing
+        expect(tree.props.style.listStyleType).toBe('upper-alpha');
+      });
+    });
+
+    describe('with nested lists and meta properties', () => {
+      const data: ListBlockData = {
+        style: 'ordered',
+        items: [
+          {
+            content: 'First level item 1',
+            items: [],
+          },
+          {
+            content: 'First level item 2',
+            items: [
+              {
+                content: 'Nested item 1',
+                items: [],
+              },
+              {
+                content: 'Nested item 2',
+                items: [],
+              },
+            ],
+          },
+        ],
+        meta: {
+          start: 3,
+          counterType: 'upper-roman',
+        },
+      };
+
+      it('renders nested <ol> blocks with inherited meta properties', () => {
+        const tree = create(<List data={data} />).toJSON();
+        expect(tree).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('renders ordered list without meta property (default behavior)', () => {
+      const data: ListBlockData = {
+        style: 'ordered',
+        items: [
+          'Item without meta',
+          'Another item',
+        ],
+      };
+
+      const tree = create(<List data={data} />).toJSON();
+      expect(tree).toMatchSnapshot();
+      // Should not have start attribute when start is 1 (default)
+      // @ts-expect-error - accessing props for testing
+      expect(tree.props.start).toBeUndefined();
+    });
+
+    it('renders unordered list without meta property', () => {
+      const data: ListBlockData = {
+        style: 'unordered',
+        items: [
+          'Bullet item',
+          'Another bullet',
+        ],
+      };
+
+      const tree = create(<List data={data} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
 });

--- a/src/renderers/list/index.tsx
+++ b/src/renderers/list/index.tsx
@@ -5,6 +5,10 @@ import { RenderFn } from '../..';
 export interface ListBlockData {
   style: 'ordered' | 'unordered';
   items: NestedListItem[];
+  meta?: {
+    start?: number;
+    counterType?: 'numeric' | 'lower-roman' | 'upper-roman' | 'lower-alpha' | 'upper-alpha';
+  };
 }
 
 export type NestedListItem =
@@ -20,22 +24,61 @@ const Group: FC<{
   Tag: keyof JSX.IntrinsicElements;
   items: NestedListItem[];
   className?: string;
-}> = ({ Tag, items, ...props }) => (
-  <Tag {...props}>
-    {items.map((item, i) => (
-      <Bullet key={i}>
-        {typeof item === 'string' ? (
-          HTMLReactParser(item)
-        ) : (
-          <>
-            {HTMLReactParser(item?.content)}
-            {item?.items?.length > 0 && <Group Tag={Tag} items={item.items} {...props} />}
-          </>
-        )}
-      </Bullet>
-    ))}
-  </Tag>
-);
+  start?: number;
+  counterType?: 'numeric' | 'lower-roman' | 'upper-roman' | 'lower-alpha' | 'upper-alpha';
+}> = ({ Tag, items, className, start = 1, counterType = 'numeric', ...props }) => {
+  const listProps: {
+    [key: string]: any;
+  } = { ...props };
+
+  if (className) {
+    listProps.className = className;
+  }
+
+  // Handle ordered list attributes
+  if (Tag === 'ol') {
+    if (start && start !== 1) {
+      listProps.start = start;
+    }
+    // Apply counter type styling
+    if (counterType && counterType !== 'numeric') {
+      const counterTypeMap: Record<string, string> = {
+        'lower-roman': 'lower-roman',
+        'upper-roman': 'upper-roman',
+        'lower-alpha': 'lower-alpha',
+        'upper-alpha': 'upper-alpha',
+      };
+      const styleType = counterTypeMap[counterType] || counterType;
+      listProps.style = { listStyleType: styleType };
+    }
+  }
+
+  return (
+    <Tag {...listProps}>
+      {items.map((item, i) => (
+        <Bullet key={i}>
+          {typeof item === 'string' ? (
+            HTMLReactParser(item)
+          ) : (
+            <>
+              {HTMLReactParser(item?.content)}
+              {item?.items?.length > 0 && (
+                <Group
+                  Tag={Tag}
+                  items={item.items}
+                  className={className}
+                  start={start}
+                  counterType={counterType}
+                  {...props}
+                />
+              )}
+            </>
+          )}
+        </Bullet>
+      ))}
+    </Tag>
+  );
+};
 
 const List: RenderFn<ListBlockData> = ({ data, className = '' }) => {
   const props: {
@@ -46,8 +89,20 @@ const List: RenderFn<ListBlockData> = ({ data, className = '' }) => {
     props.className = className;
   }
 
+  const { start = 1, counterType = 'numeric' } = data?.meta || {};
   const Tag = (data?.style === 'ordered' ? `ol` : `ul`) as keyof JSX.IntrinsicElements;
-  return data && <Group Tag={Tag} items={data.items} {...props} />;
+
+  return (
+    data && (
+      <Group
+        Tag={Tag}
+        items={data.items}
+        start={start}
+        counterType={counterType}
+        {...props}
+      />
+    )
+  );
 };
 
 export default List;


### PR DESCRIPTION
## Description
Adds support for the `meta` property in Editor.js list blocks, which includes `start` (custom starting number) and `counterType` (numeric, roman, alpha) properties.

## Changes
- Added `meta?: { start?: number; counterType?: ... }` to `ListBlockData` interface
- Added `start` and `counterType` props to `Group` component
- Implemented `start` attribute for ordered lists
- Implemented `counterType` inline styling using `listStyleType`
- Fully backward compatible

## Testing
- All existing tests pass ✓
- Added comprehensive tests covering:
  - Custom start values (1, 2, 3, 5, etc.)
  - All counter types (numeric, lower-roman, upper-roman, lower-alpha, upper-alpha)
  - Combined start + counterType
  - Nested lists with inherited meta properties
  - Backward compatibility (lists without meta)

## Related
Addresses Editor.js now providing `meta` property in list blocks.